### PR TITLE
Meta viewport

### DIFF
--- a/src/ui/app.jsx.js
+++ b/src/ui/app.jsx.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import Module from '../assignments/module-0/index.jsx'
+import Module from '../assignments/project-1/index.jsx'
 
 const App = ({auth, ...props}) => {
 	switch (auth.status) {

--- a/src/ui/app.jsx.js
+++ b/src/ui/app.jsx.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import Module from '../assignments/project-1/index.jsx'
+import Module from '../assignments/module-0/index.jsx'
 
 const App = ({auth, ...props}) => {
 	switch (auth.status) {

--- a/src/ui/index.pug
+++ b/src/ui/index.pug
@@ -4,6 +4,7 @@ html(lang='en')
 		title module-0
 		link(rel="stylesheet" href="/css/module-0/app.css")
 		link(rel="stylesheet" href="https://fonts.googleapis.com/css?family=Permanent+Marker")
+		meta(name="viewport" content="width=device-width, initial-scale=1")
 	body
 		#app !{app}
 		script(src="/js/app.js")

--- a/src/ui/index.pug
+++ b/src/ui/index.pug
@@ -4,7 +4,6 @@ html(lang='en')
 		title module-0
 		link(rel="stylesheet" href="/css/module-0/app.css")
 		link(rel="stylesheet" href="https://fonts.googleapis.com/css?family=Permanent+Marker")
-		meta(name="viewport" content="width=device-width, initial-scale=1")
 	body
 		#app !{app}
 		script(src="/js/app.js")

--- a/src/ui/index.pug
+++ b/src/ui/index.pug
@@ -1,12 +1,8 @@
 doctype html
 html(lang='en')
 	head
-<<<<<<< HEAD
-		link(rel="stylesheet" href="/css/project-1/app.css")
-=======
 		title module-0
 		link(rel="stylesheet" href="/css/module-0/app.css")
->>>>>>> 79e0c469d8d2d4c301803ad9a78469454d178c92
 		link(rel="stylesheet" href="https://fonts.googleapis.com/css?family=Permanent+Marker")
 	body
 		#app !{app}

--- a/src/ui/index.pug
+++ b/src/ui/index.pug
@@ -1,7 +1,7 @@
 doctype html
 html
 	head
-		link(rel="stylesheet" href="/css/module-0/app.css")
+		link(rel="stylesheet" href="/css/project-1/app.css")
 		link(rel="stylesheet" href="https://fonts.googleapis.com/css?family=Permanent+Marker")
 	body
 		#app !{app}


### PR DESCRIPTION
Add [meta viewport](https://developer.mozilla.org/en-US/docs/Mozilla/Mobile/Viewport_meta_tag) element to head in index.pug to make web page load responsively on mobile devices.